### PR TITLE
Change `response` fn to return `Result`. 404 on unknown requests. v0.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sled-web"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["mitchmindtree <mitchell.nordine@gmail.com>"]
 description = "An extension of the `sled` crate that allows for accessing a `sled::Tree` via a client/server API using the `hyper` web framework crate."
 readme = "README.md"

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,7 +1,7 @@
 use hyper::{self, Server};
 use hyper::rt::Future;
 use hyper::service::service_fn;
-use response::response;
+use response::{or_404, response};
 use sled;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -63,12 +63,15 @@ impl ConfigBuilder {
 /// Build the hyper `Server` with the given configuration and `sled::Tree`.
 ///
 /// Returns a `Future` representing the `Server`'s computation.
+///
+/// To create and run your own server you can use the `response` function which simply translates
+/// requests to response futures.
 pub fn new(config: Config, tree: Arc<sled::Tree>) -> impl Future<Item = (), Error = hyper::Error> {
     Server::bind(&config.addr)
         .serve(move || {
             let tree = tree.clone();
             service_fn(move |req| {
-                response(req, tree.clone())
+                or_404(response(req, tree.clone()))
             })
         })
 }


### PR DESCRIPTION
This allows for checking other `response` type functions in the case
that there are no `METHOD` and `URI` matches.

The `server::new` and `server::run` fns will now responsd with a 404
status on unknown requests rather than panicking.